### PR TITLE
Hook up wiki instance to mysql instance on fly.io

### DIFF
--- a/docker/mysql.fly.dockerfile
+++ b/docker/mysql.fly.dockerfile
@@ -1,0 +1,3 @@
+FROM mariadb:latest
+
+COPY ./docker/sql /docker-entrypoint-initdb.d

--- a/docker/todo.dockerfile
+++ b/docker/todo.dockerfile
@@ -13,7 +13,11 @@ COPY --from=composer /var/www/vendor/ vendor
 
 RUN docker-php-ext-install pdo pdo_mysql
 RUN pecl install xdebug && docker-php-ext-enable xdebug
+
 ENV ENV .todo.env.docker
+ENV DB_HOST=mysql
+ENV DB_USER=cloudmaker
+ENV DB_PASS=avocado
 
 ### Install nginx
 RUN apt update

--- a/docker/wiki.dockerfile
+++ b/docker/wiki.dockerfile
@@ -13,7 +13,11 @@ COPY --from=composer /var/www/vendor/ vendor
 
 RUN docker-php-ext-install pdo pdo_mysql
 RUN pecl install xdebug && docker-php-ext-enable xdebug
+
 ENV ENV .wiki.env.docker
+ENV DB_HOST=mysql
+ENV DB_USER=cloudmaker
+ENV DB_PASS=avocado
 
 ### Install nginx
 RUN apt update

--- a/mysql.fly.toml
+++ b/mysql.fly.toml
@@ -1,0 +1,20 @@
+# fly.toml app configuration file generated for mysql-srv on 2023-12-15T14:09:06-08:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = "mysql-srv"
+primary_region = "sjc"
+
+kill_signal = "SIGINT"
+kill_timeout = 5
+
+[mounts]
+  source="mysqldata"
+  destination="/var/lib/mysql"
+
+[processes]
+  app = ""
+
+[build]
+  dockerfile = "./docker/mysql.fly.dockerfile"

--- a/src/.todo.env.docker
+++ b/src/.todo.env.docker
@@ -3,7 +3,4 @@ BASE_URL=http://localhost:9090/
 APP_NAME=Task0
 SITE_TYPE=todo
 
-DB_HOST=mysql
 DB_NAME=todo
-DB_USER=cloudmaker
-DB_PASS=avocado

--- a/src/.wiki.env.docker
+++ b/src/.wiki.env.docker
@@ -3,10 +3,7 @@ BASE_URL=http://localhost:7070/
 APP_NAME=Wiki0
 SITE_TYPE=wiki
 
-DB_HOST=mysql
 DB_NAME=wiki
-DB_USER=cloudmaker
-DB_PASS=avocado
 
 TODO_HOSTNAME=localhost:9090
 TODO_TOKEN_ENDPOINT=http://localhost:9090/oauth/token

--- a/wikisrv.fly.toml
+++ b/wikisrv.fly.toml
@@ -9,6 +9,10 @@ primary_region = "sjc"
 [build]
   dockerfile = "./docker/wikisrv.fly.dockerfile"
 
+[env]
+  DB_HOST = "mysql-srv.internal"
+  DB_NAME = "wiki"
+
 [http_service]
   internal_port = 80
   force_https = true

--- a/wikisrv.fly.toml
+++ b/wikisrv.fly.toml
@@ -11,7 +11,6 @@ primary_region = "sjc"
 
 [env]
   DB_HOST = "mysql-srv.internal"
-  DB_NAME = "wiki"
 
 [http_service]
   internal_port = 80


### PR DESCRIPTION
This PR hooks up wiki to mysql.  Next up I'll add the configuration files for todo and also hook it up to mysql.

After that we'll need to set up our cloudmaker demo okta org ideally in our demo cell and then we can connect all the pieces together.